### PR TITLE
experience updated

### DIFF
--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -307,6 +307,8 @@ DivideExpDataByNumMonsGainingExp:
 	jr nz, .countSetBitsLoop
 	cp $2
 	ret c ; return if only one mon is gaining exp
+	;Always halve XP before sharing. Bigger parties = Better
+	ld a, $02
 	ld [wd11e], a ; store number of mons gaining exp
 	ld hl, wEnemyMonBaseStats
 	ld c, wEnemyMonBaseExp + 1 - wEnemyMonBaseStats


### PR DESCRIPTION
Bigger parties = Better now
Experience reduction is capped at 50% rather than 16%

This makes gaining XP in safari mode much more fun. Works well with #36 to create a stable and enjoyable gameplay loop around catching and transferring pokemon.